### PR TITLE
Fixed non-profit language

### DIFF
--- a/content/en/about/_index.html
+++ b/content/en/about/_index.html
@@ -9,72 +9,75 @@ pre = "<i class='fas fa-file-signature pr-2'></i>"
 {{% blocks/link-down color="info" %}}
 {{% /blocks/cover %}}
 {{% blocks/section type="section" color="white" %}}
-# Mission Statement
-The Nivenly Foundation brings sustainability, autonomy, and control to open source projects and communities around the
-globe. We set the precedent for member-owned and democratically-governed technical organizations. We offset the negative
-impact of profit-driven economies through the use of a nonprofit association that protects and supports the contributors
-and maintainers of technical projects, establishing sustained independence from the corporations that use them.
 
-Nivenly believes that all members of a project should own the project and share in its success.
+### Mission Statement
 
+The Nivenly Foundation is founded on the principle that project maintainers should share in their projects’
+success. The Nivenly Foundation brings sustainable governance to open source projects and communities around
+the globe and supports the maintainers’ independent oversight of their projects.  We are a decentralized,
+democratically-governed non-profit technical organization, that focuses on building an equitable future for
+technology communities.   
 
-# History
+### History
 
-In June 2022, Kris Nóva started the Aurae runtime project as the culmination of her lifetime of experience developing,
-deploying, securing, and maintaining distributed production infrastructure in enterprise-scale cloud architectures.
-However, she wasn’t convinced she had found an appropriate home to continue incubating the project.
+In June 2022, Kris Nóva started the Aurae runtime project as the culmination of her lifetime of experience
+developing, deploying, securing, and maintaining distributed production infrastructure in enterprise-scale
+cloud architectures. However, she couldn’t find an appropriate home to continue incubating the project,
+where she felt she could maintain oversight of the integrity of the project. During the same timeframe she
+began serving an independent Mastodon instance in her basement, Hachyderm, which grew from approximately
+700 users before November 2022 to 40,000 users by December 2022. Similar to Aurae, Hachyderm’s growth
+signaled that it would need an entity to call home. 
 
-Aurae is a remote process execution utility that aims to be the most effective way to schedule workloads such as
-containers and virtual machines on a single node using a common API intended to work with many orchestration systems and
-networking providers.
+She also saw so many other maintainers in open source facing the same problem - they need a foundation to
+help them scale their project but they don’t want to lose the ability to cooperatively steer their project’s
+direction and maintain its integrity. So, she got to work creating a place maintainers can call home.
 
-Aurae is influenced by Nóva’s distributed systems experience and security response in enterprise cloud. The hope is that
-by bringing a better set of remote controls to a node, Aurae can unlock brilliant higher order distributed systems in
-the future. Nóva will be presenting a deep technical analysis of Aurae live at FOSDEM in February of 2023.
+#### Announcing the Nivenly Foundation
 
-In April of 2022, Kris Nóva began serving an independent Mastodon instance in her basement along with her Twitch
-community, fellow Aurae contributors and maintainers, and other container, Rust, and Go hackers. She named the instance
-“Hachyderm” as a play on words combining “Hacking” and “Pachyderm”. In November of 2022, a mass exodus from Twitter
-shook the social media industry, pushing control of feeds and timelines away from centralized services and into smaller,
-independently-managed, decentralized entities. Hachyderm absorbed some of this migration, growing first from less than
-1,000 users to 30,000 users in November and then to 40,000 users the following month. Today, Hachyderm is a thriving
-social media community moderated and operated by a small group of volunteers whose efforts, technical prowess, and
-amazing collaborative skills have inspired even greater desire for a sustainable open source support model.
+We are thrilled to announce the Nivenly Foundation: a democratically run nonprofit on a mission to bring
+sustainable governance and autonomy to open source projects and communities around the globe. The founders'
+dream for the Nivenly Foundation is to provide an exciting and equitable future for the next generation of
+technologists.  
 
-Today, Kris Nóva is thrilled to announce the Nivenly Foundation: a member-owned 501(c)(3) registered nonprofit
-corporation on a mission a nonprofit Private Foundation qualified under IRC § 501(c)(3) whose mission is to bring
-sustainability, ownership, and control to open source projects and communities around the globe.
+<!-- FIXME: Blockquote not rendering -->
 
-The industry is thirsty for a community balance. She believes the place to gain traction is with an ownership model
-built around the idea there is more to open source software than corporations. “An industry without a balance in
-ownership is no different than a hostile corporate monopoly without competition”, cited Nóva. “We want the people
-working on the projects to be the same people who own and benefit from the success.” For the industry to sustain the
-next generations, she believes balance must be struck between the individuals who build and maintain projects, and the
-corporations that leverage them. This begins by placing ownership and control back in the hands of the open source
-community and maintainers.
+> “The Nivenly Foundation will establish a path forward for general computer science to flourish with
+> inclusive communities, rather than profit-driven entities dictating its direction. We dream that one day,
+> young and marginalized technologists will experience intellectual equity in the industry.“
+> <br /><br />
+> -- Kris Nóva
 
-The founders' dream for the Nivenly Foundation is to provide an exciting and equitable future for the next generation of
-technologists. The Nivenly Foundation will establish a path forward for general computer science to thrive without
-profit-driven entities dictating its direction. We dream that one day, young and marginalized technologists will
-experience ownership and equity in the industry. The Nivenly Foundation will provide a crucible in which computer
-science, altruism, and collaborative methodology can thrive without the influence of corporate product marketing tactics
-that distract from projects’ directions and destroy their potential. We believe that well-maintained and well-operated
-open source projects are the key to unlock this future.
+The industry is thirsty for a community balance. For the industry to sustain future generations, there must
+be balance between the individuals who build and maintain projects, and the corporations that leverage them.
+The founders of the Nivenly Foundation believe that the way to create this balance is through a community model
+built around the idea that open source software is for everyone. “An industry without a balance in control is
+no different than a hostile corporate monopoly without competition”, said Nóva. “We want the people working on
+projects to be the same people who benefit from the success of those projects. This begins by placing control
+back in the hands of the open source community and maintainers.” 
 
-The Nivenly Foundation will employ a cooperative and egalitarian ownership model. The community members that maintain
-and contribute to the projects will own the projects and have a democratic voice in the decision-making process. The
-details of how this democratic process will function will be published and vetted with the community in the coming
-weeks. Nivenly’s obligation is to serve the general public interest without profit-driven obligations to its own
-members; thus, the Foundation will operate without financial bias or “pay-to-play” tactics. The Foundation will support
-educational resources, training, and research for public computer science, analogous to how the International Space
-Station serves as an international laboratory.
+#### Why Nivenly Foundation is Different
+
+The Nivenly Foundation provides a crucible in which computer science, altruism, and collaborative methodology
+can thrive without the influence of corporate product marketing tactics that distract from projects’ directions
+and co-opt their potential. “We believe that well-maintained and well-operated open source projects are the key
+to unlock this future,” Nova said. And so, Nivenly’s first order of business is establishing the governance and
+financial model designed to support the maintainers of the projects while giving a democratic vote and voice to
+all members of the foundation.
+
+The Nivenly Foundation creates a cooperative and egalitarian governance model, designed to serve the public
+interest of its communities without profit-driven obligations. The community maintainers and contributors are
+empowered to preserve the integrity and advancement of their projects through a democratic voice in the
+decision-making process. The details of how this democratic process will function will be published and vetted
+with the community in the coming weeks. We envision that the Foundation will support educational resources,
+training, and research for public computer science, analogous to how the International Space Station serves as
+an international laboratory. 
+
+#### Nivenly’s Team and First Projects
 
 The Aurae runtime project and the Hachyderm social media platform will be the first projects to come under the
-stewardship of the Nivenly Foundation. Quintessence Anx will join Nivenly as the Executive Director. Dominic Hamon joins
-Kris Nóva as the initial Board of Directors, with additional Directors expected to be named in January. Their
-biographies can be found [here](/who).
-
-The first order of business will be establishing the governance and financial model designed to support the maintainers
-of the projects while giving a democratic vote and voice to all members of the foundation.
+stewardship of the Nivenly Foundation. Quintessence Anx will join Nivenly as the Executive Director. Dominic
+Hamon, Preston Doster, Mekka Okereke, and Molly Monroy join Kris Nóva as the initial Board of Directors.
+[Their biographies are on our "Who" page](/who/). More information about Nivenly's projects is located on
+[our "Projects" page](/projects/).
 
 {{% /blocks/section %}}


### PR DESCRIPTION
Fixed non-profit language to not call out our intended status prematurely, also removed usage of "ownership" to prevent confusion with "shareholder" style ownership.