### PR TITLE
Update FSEP paper feature section 1 to clarify onboarding features

### DIFF
--- a/content/en/docs/papers/fsep/_index.md
+++ b/content/en/docs/papers/fsep/_index.md
@@ -114,8 +114,9 @@ The administration onboarding process can be enhanced by leveraging the addition
 
 | ID | FEATURE | PRIORITY |
 |:--|:--|:--|
-| 1.1 | At setup time, administrators should be able to upload a deny list or select a default to deny list provided. For MVP, only one deny list provider needs to be supported in this list (The Bad Space). Ultimately, the goal is to allow users to choose from one of several vetted tier 0 lists. | P1 |
+| 1.1 | At setup time, administrators should be able to upload a deny list or select a default to deny list provided by a deny list provider. For MVP, only one deny list provider needs to be supported in this list (The Bad Space). Ultimately, the goal is to allow users to choose a deny list from one of several vetted providers. | P1 |
 | 1.2 | At setup time, administrators should be able to select whether or not they want the default deny list to auto-update. If the admin selects “yes,” the list should attempt to auto-update once every 24 hrs.  | P1 |
+| 1.3 | At setup time, administrators should be able to view the techniques and policies used by each provider to create each deny list in full, during the setup process, from the list of providers, by clicking on links associated directly with each deny list and provider.  | P1 |
 
 ### Deny List Management
 


### PR DESCRIPTION
Here, I've suggested two changes to the FSEP paper.

First, to clarify the distinction between "deny lists" and "deny list providers"; presumably, one provider could offer multiple lists, as observed in the many algorithmic combinations provided by [oliphant.social](https://writer.oliphant.social/oliphant/the-oliphant-social-blocklist).

Second, to add a feature for the MVP stage of implementation that allows administrators to better understand what they are opting into when they choose a particular list. This change is guided by my frustration with app stores, plugin directories, server browsers, and the like which lack robust hypertext tools and description fields and thereby ask users to make a decision with a very limited amount of information. Ideally, an admin could read, or at least glance at, all the policies of available deny lists and then choose the one that best suits the experience they're looking for.

I have signed the CLA.