### PR TITLE
Blog post re: OCF wind-down

### DIFF
--- a/content/en/blog/2024/2024-03-02-open-collective-and-nivenly.md
+++ b/content/en/blog/2024/2024-03-02-open-collective-and-nivenly.md
@@ -1,0 +1,13 @@
+---
+title: "Open Collective Foundation and Nivenly"
+linkTitle: OCF and Nivenly
+date: 2024-03-02
+author: esk ([@esk](https://hachyderm.io/@esk))
+description: Clarifies there is no impact to Nivenly from the OCF wind-down
+---
+
+tl;dr - there is no impact to Nivenly or our operations.
+
+The [Open Collective Foundation (OCF)](https://opencollective.foundation/) recently announced [they will dissolve at the end of 2024](https://opencollective.com/foundation/updates/announcement-we-are-dissolving-open-collective-foundation-at-the-end-of-this-year). The Foundation is a fiscal host that happens to share a name with the software, Open Collective. While Nivenly **does** leverage the [Open Collective](https://opencollective.com/nivenly-foundation) *software* to manage our member list and a "front door" for donations, we **do not** use the Open Collective Foundation as our fiscal host. Instead, we act as our own fiscal host and are responsible for managing our own bank account, accounting ledger, and tax preparations.
+
+Because we're not using the Foundation as a fiscal host, there is no impact to Nivenly as a result of OCF's actions.


### PR DESCRIPTION
A blog post that clarifies that there is no impact to Nivenly as a result of the OCF wind-down.