### PR TITLE
Improve view of /who on smaller viewports

### DIFF
--- a/content/en/who/_index.html
+++ b/content/en/who/_index.html
@@ -21,7 +21,7 @@ pre = "<i class='fas fa-people-group pr-2'></i>"
           Nivenly, as well as representing the interests of our membership and oversee our governance processes.
         </p>
         <!-- Quintessence Anx -->
-        <div class="col-4">
+        <div class="col-sm-4">
            <div class="card border-primary-dark">
               <img src="quintessence.jpg"
                  class="card-img-top"
@@ -47,7 +47,7 @@ pre = "<i class='fas fa-people-group pr-2'></i>"
            </div>
         </div>
         <!-- Dominic Hamon -->
-        <div class="col-4">
+        <div class="col-sm-4">
            <div class="card border-primary-dark">
               <img src="dma.png"
                  class="card-img-top"
@@ -75,7 +75,7 @@ pre = "<i class='fas fa-people-group pr-2'></i>"
            </div>
         </div>
         <!-- Preston Doster -->
-        <div class="col-4">
+        <div class="col-sm-4">
            <div class="card border-primary-dark">
               <img src="preston-doster-300x300.png"
                  class="card-img-top"


### PR DESCRIPTION
There wasn't an issue created for this, but it was reported on the Discord.

Before

<details>
<img src="https://github.com/user-attachments/assets/7fab9f81-d124-44d9-af6d-601abf364543" />
</details>

Now at above 576 pixels

<details>
<img src="https://github.com/user-attachments/assets/7b878a83-2811-412c-ab6f-5444da00ad84" />
</details>

versus below

<details>
<img src="https://github.com/user-attachments/assets/23efeabc-543a-4762-a7e2-7b5ea0980df8" />
</details>

Docs - https://getbootstrap.com/docs/5.3/layout/grid/