### PR TITLE
Add Request for Payment section to fediverse security fund docs

### DIFF
--- a/content/en/docs/programs/fediverse-security-fund.md
+++ b/content/en/docs/programs/fediverse-security-fund.md
@@ -105,6 +105,10 @@ These projects are included within the Fund, however, their responsible security
 
 Projects can let us know of changes to their security practices via a ticket at [nivenly/community](https://github.com/nivenly/community/issues).
 
+## Requests for Payment
+
+Please fill in [this form](https://docs.google.com/forms/d/e/1FAIpQLSdxWsU24HflOr2EFHeL_XMgVP1omkREHVFH7G5f0hWZd3ojEQ/viewform) make a request for payment for a vulnerability. If we need more information, we'll get in contact with you via email, which is also how we will provide updates on your request.
+
 ## Resources for Responsible Security Practices
 
 - [Github on Coordinated Disclosure of Security Vulnerabilities](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/about-coordinated-disclosure-of-security-vulnerabilities)


### PR DESCRIPTION
Previously we didn't have any instructions for how to actually apply to receive payment from the Fediverse Security Fund. This changeset introduces a Google Form (for now) through which interested persons can request a payment from the Fediverse Security Fund.

This also gives us a process through which to review and ensure payments are made when requested, so we don't loose track of things.

Addresses some of https://github.com/nivenly/community/issues/10 — I believe there's still some unanswered questions.

<img width="1912" height="1068" alt="image" src="https://github.com/user-attachments/assets/34032b8d-4d95-4548-b4b0-837efe2d663a" />
