### PR TITLE
build(mise): Add entries for hugo-extended and golang

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,4 @@
 # make sure to update .github/workflows/publish.yml as well!
-hugo extended_0.147.3
+hugo          extended_0.147.3
+hugo-extended 0.147.3
+golang        1.24.6

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,5 @@
 # make sure to update hugo version in .github/workflows/publish.yml as well!
+# "hugo" is for asdf, "hugo-extended" is for mise:
 hugo          extended_0.147.3
 hugo-extended 0.147.3
 golang        1.24.6

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-# make sure to update .github/workflows/publish.yml as well!
+# make sure to update hugo version in .github/workflows/publish.yml as well!
 hugo          extended_0.147.3
 hugo-extended 0.147.3
 golang        1.24.6


### PR DESCRIPTION
https://mise.jdx.dev/ is an "asdf" alternative I use that also reads from the .tool-versions file.

This change:

- Adds an entry for `golang`. Mise isn't written in Go, so you can't assume Go is already installed on the user's system.

- Adds an entry for `hugo-extended`. Because we don't deserve nice things the asdf folks appear to have decided that `extended` is part of the version component, while the mise folks decided it's part of the package name.

With this change someone who uses Mise can `cd` to the `website` directory and `mise` will ensure the correct tools are installed so that `make dev` works immediately.

While I'm here, make the comment about `publish.yml` more specific.