### PR TITLE
Remove min-height 100vh on cards

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -360,7 +360,6 @@ footer {
   .card {
     border: none;
     position: relative;
-    min-height: 100vh;
     justify-items: start;
 
     &::before,


### PR DESCRIPTION
This fixes #105

I'm sure there's a reason I added it, but I can't see that issue now, so I'm okay landing this change. Thanks for finding it @nikclayton 