### PR TITLE
Fix: extensive mobile layout fixes

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -200,9 +200,19 @@ p,ul,ol {
         padding: 0;
       }
     }
+
+    .td-sidebar__search {
+      padding-top: 0;
+    }
     
-    .td-sidebar-toc, .td-section-nav {
-      top: 10rem!important;
+    .td-sidebar-toc, .td-sidebar__inner {
+      top: 12rem!important;
+    }
+
+    @include media-breakpoint-up(md) {
+      .td-sidebar__inner {
+        padding-left: 1rem;
+      }
     }
   }
   
@@ -292,13 +302,6 @@ p,ul,ol {
       font-weight: 500;
       padding-left: 0.5rem;
     }
-
-    @include media-breakpoint-up(md) {
-      .td-sidebar__inner {
-        padding-top: 30px;
-        top: 6rem;
-      }
-    }
   }
 
   @include media-breakpoint-down(md) {
@@ -326,6 +329,10 @@ p,ul,ol {
 
   .td-breadcrumbs__single {
     display: none;
+  }
+
+  .td-sidebar-nav .td-sidebar-link.tree-root {
+    border-color: #ccc;
   }
   
 

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -172,9 +172,10 @@ p,ul,ol {
 // --------------------------------------------------
 // remove whitespace after footer
 // --------------------------------------------------
-footer {
-    min-height: auto;
-  }
+.td-footer {
+  min-height: auto!important;
+  padding: 3rem 0;
+}
   
   // --------------------------------------------------
   // prevent overflow of long names in sidebar
@@ -194,16 +195,38 @@ footer {
       padding-top: 12px;
       z-index: 33;
       background: $primary;
-    }
 
+      @include media-breakpoint-down(md) {
+        padding: 0;
+      }
+    }
+    
     .td-sidebar-toc, .td-section-nav {
-      top: 7rem!important;
+      top: 10rem!important;
     }
   }
+  
+  @include media-breakpoint-down(md) {
+    header {
+      .navbar-nav-scroll {
+        align-items: start;
+        
+        &:has([aria-expanded="true"]) {
+          align-items: start;
+          min-height: var(--bs-scroll-height, 100vh);
+          padding-bottom: 3rem;
+        }
 
-  @include media-breakpoint-down(lg) {
-    .td-sidebar {
-      padding-top: 0!important;      
+        .navbar-collapse.collapsing {
+          transition: height 0.35s ease-out;
+        }
+
+        .navbar-nav {
+          padding-top: 1rem;
+          padding-left: 24px!important;
+        }
+      }
+
     }
   }
 
@@ -226,46 +249,94 @@ footer {
           border-top: none;
           width: 60px;
           height: 60px;
+          margin-bottom: 10px;
   
           @include media-breakpoint-down(lg) {
             max-width: 55px;
             max-height: 55px;
             padding: 0px;
             margin-top: 0px;
-            margin-bottom: 10px;
+            margin-bottom: 0px;
           }
         }
       }
     }
 
-    .navbar-toggler:focus {
-      box-shadow: 0 0 0 2px;
+    .navbar-toggler {
+      margin-right: 24px;
+
+      &:focus {
+        box-shadow: 0 0 0 2px;
+      }
     }
 
     .navbar-collapse.show,
     .navbar-collapse.collapsing {
-      padding-top: 1rem;
       padding-bottom: 1rem;
     }
   }
 
   // Fixes the issue with the headers not being full width:
   .container-fluid.td-default.td-outer {
-    padding-left: 0;
-    padding-right: 0;
+    padding-left: 0!important;
+    padding-right: 0!important;
   }
   
   .td-sidebar {
-    padding-top: 10px;
-    padding-bottom: 0.5rem;
+    padding: 1rem 0 0;
   
-    .td-sidebar__search {
-        display: none!important;
+    .td-sidebar__toggle:after {
+      content: "Menu";
+      position: relative;
+      font-family: var(--bs-body-font-family);
+      font-weight: 500;
+      padding-left: 0.5rem;
+    }
+
+    @include media-breakpoint-up(md) {
+      .td-sidebar__inner {
+        padding-top: 30px;
+        top: 6rem;
       }
+    }
+  }
+
+  @include media-breakpoint-down(md) {
+    .td-blog #td-sidebar-menu {
+      display: none;
+    }
+
+    .td-sidebar__search {
+      padding: 0;
+    }
 
     .td-sidebar__inner {
-      padding-top: 30px;
-      top: 6rem;
+      padding-bottom: 1rem;
+    }
+
+    .td-sidebar-nav {
+      margin-left: -0.5rem;
+      margin-right: 0.5rem;
+    }
+
+    .td-sidebar-nav__section .ul-1 ul {
+      padding-left: 1.5rem;
+    }
+  }
+
+  .td-breadcrumbs__single {
+    display: none;
+  }
+  
+
+  @include media-breakpoint-down(md) {
+    .td-breadcrumbs {
+      border-top: 1px solid #ccc;
+      padding-top: 1rem;
+    }
+
+    .td-404 main, .td-main main {
+      padding-top: var(--bs-gutter-y);
     }
   }
   

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,6 +1,7 @@
 <footer class="td-footer row d-print-none">
   <div class="container-fluid">
-    <div class="d-flex justify-content-between align-items-center align-content-center px-4">
+    <div
+      class="d-flex flex-column flex-lg-row justify-content-between align-items-center align-content-center gap-3 px-2">
       <div class="td-footer__left">
         {{ partial "footer/left.html"  . }}
       </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,17 @@
+<footer class="td-footer row d-print-none">
+  <div class="container-fluid">
+    <div class="d-flex justify-content-between align-items-center align-content-center px-4">
+      <div class="td-footer__left">
+        {{ partial "footer/left.html"  . }}
+      </div>
+      {{- /* Trim WS */ -}}
+      <div class="td-footer__center flex-fill">
+        {{ partial "footer/center.html"  . }}
+      </div>
+      {{- /* Trim WS */ -}}
+      <div class="td-footer__right">
+        {{ partial "footer/right.html"  . }}
+      </div>
+    </div>
+  </div>
+</footer>

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,0 +1,1 @@
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, shrink-to-fit=no">

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,5 +1,5 @@
 {{ $cover := and (.HasShortcode "blocks/cover") (not .Site.Params.ui.navbar_translucent_over_cover_disable) }}
-<nav class="navbar navbar-expand-xxl navbar-dark">
+<nav class="navbar navbar-expand-xxl navbar-dark navbar-nav-scroll">
 	<div class="container-fluid">
 		<a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
 			<span
@@ -11,7 +11,7 @@
 			<span class="navbar-toggler-icon"></span>
 		</button>
 		<div class="collapse navbar-collapse" id="navbar">
-			<ul class="navbar-nav ms-xl-auto mb-2 mb-xxl-0 ms-lg-2 navbar-nav-scroll">
+			<ul class="navbar-nav ms-xl-auto mb-2 mb-xxl-0 ms-lg-2">
 				{{ $p := . }}
 				{{ range .Site.Menus.main }}
 				<li class="nav-item py-sm-1">


### PR DESCRIPTION
This fixes the:
- navigation scrolling and sizing (though there's still white bands to either side of the page on iPhones with a top-notch, I can't manage to get rid of this)
- fixes the footer layout on mobile, where we use a single-column layout for the three components, but on larger devices we use a multi-column layout
- fixes the section navigation not being visible on mobile, this allows us to get around between the different pages in the documentation (this is explicitly hidden on the blog layout though)
- hides the breadcrumbs if there's only a single one, since it just looks weird.
