### PR TITLE
build: Ignore mise.local.toml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ resources/_gen*
 .smbdelete*
 .hugo_build.lock
 .vscode*
+mise.local.toml


### PR DESCRIPTION
These files contain definitions for tools local to a developer that are not necessary for building the site. For example, if someone uses a git wrapper or git-compatible VCS they would add it to their mise.local.toml file. These are not intended to be committed.