### PR TITLE
fix: Make Aurae card heading a link

### DIFF
--- a/layouts/shortcodes/shared/projects.html
+++ b/layouts/shortcodes/shared/projects.html
@@ -3,7 +3,9 @@
 		<div class="card-body">
 			<a href="https://aurae.io">
 				<img src="/project-logos/aurae.png" class="card-img-top" draggable="false" alt="Logo for Aurae" />
-                <h5 class="card-title section-head">Aurae</h5>
+				<h5 class="card-title section-head">
+					Aurae
+				</h5>
 			</a>
 			<p class="card-text">
 				Aurae is a free and open source Rust project providing a memory-safe


### PR DESCRIPTION
The other projects all have their card heading (the h5 element) inside the link, so the heading is underlined and linked. The Aurae card wasn't like that.