### PR TITLE
Fediverse Security Fund: Update projects eligible list

### DIFF
--- a/content/en/docs/programs/fediverse-security-fund.md
+++ b/content/en/docs/programs/fediverse-security-fund.md
@@ -73,6 +73,7 @@ The following projects are currently included and meet the above minimum require
 * [Manyfold](https://github.com/manyfold3d/manyfold)
 * [Mastodon](https://github.com/mastodon/mastodon)
 * [Misskey](https://github.com/misskey-dev/misskey)
+* [Mitra](https://codeberg.org/silverpill/mitra)
 * [NeoDB](https://github.com/neodb-social/neodb/)
 * [NodeBB](https://nodebb.org/)
 * [PeerTube](https://github.com/Chocobozzz/PeerTube)
@@ -80,6 +81,7 @@ The following projects are currently included and meet the above minimum require
 * [Pleroma](https://git.pleroma.social/pleroma/pleroma)
 * [Owncast](https://github.com/owncast/owncast/)
 * [Sharkey](https://activitypub.software/TransFem-org/Sharkey)
+* [Vernissage (server)](https://github.com/VernissageApp/VernissageServer)
 * [WriteFreely](https://github.com/writefreely/writefreely)
 * [Wafrn](https://github.com/gabboman/wafrn)
 
@@ -95,11 +97,9 @@ These projects are included within the Fund, however, their responsible security
 * [Flohmarkt](https://codeberg.org/flohmarkt/flohmarkt)
 * [Friendica](https://github.com/friendica/friendica)
 * [Funkwhale](https://dev.funkwhale.audio/funkwhale/funkwhale)
-* [Mitra](https://codeberg.org/silverpill/mitra)
 * [Postmarks](https://github.com/ckolderup/postmarks)
 * [Snac2](https://codeberg.org/grunfink/snac2)
 * [Smithereen](https://github.com/grishka/Smithereen)
-* [Vernissage (server)](https://github.com/VernissageApp/VernissageServer)
 
 
 Projects can let us know of changes to their security practices via a ticket at [nivenly/community](https://github.com/nivenly/community/issues).


### PR DESCRIPTION
I've reviewed the various projects that were listed as provisionally eligible, and some have moved up to eligible, e.g., [castopod](https://code.castopod.org/adaures/castopod/-/blob/develop/CONTRIBUTING.md?ref_type=heads#%EF%B8%8F-security-issues-and-vulnerabilities)

I've also filed issues requesting security policies from snac2, vernissage, flohmarkt and others.