### PR TITLE
Fix failing deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     tags:
-      - '*'
+      - "*"
     branches:
       - main
   pull_request:
@@ -26,5 +26,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
       - run: npm install -g pajv
+      - name: Validate data schemas
+        run: make validate
       - name: Build
         run: make hugo

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ validate:
 issues: ## Find all the FIXMEs
 	grep -ri "FIXME" content/en/
 
-hugo: validate
+hugo:
 	npm ci
 	hugo --minify
 


### PR DESCRIPTION
By change `make hugo` to run the validations, this broke the deploy action, due to a missing dependency. This instead makes the validate step explicitly run, which in turn fixes the deployment.