### PR TITLE
change: Disable git info

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,8 +10,8 @@ enableMissingTranslationPlaceholders = true
 
 enableRobotsTXT = true
 
-# Will give values to .Lastmod etc.
-enableGitInfo = true
+# Disable fetching and displaying git commit info on some pages.
+enableGitInfo = false
 enableEmoji = true
 
 ignoreFiles = ["data/validate.sh", "data/(.*).schema.json", "data/README.md"]


### PR DESCRIPTION
With `enableGitInfo` set to `true` the docsy theme shows information about the most recent commit to the file at the bottom of some pages.

This is

a. Inconsistent -- it only appears at the bottom of blog pages.

b. Actively misleading -- e.g. right now the bottom of https://nivenly.org/blog/2024/12/31/nivenlys-2024-financial-report/ looks like:

> Last modified August 30, 2025: feat(blog): Announce Pachli 2.16.0 (#118) (47ff4b6)

That might make you think the commit that added the Pachli blog entry also modified the financial report blog entry. It didn't, the footer is showing the most recent commit to the site as a whole.

So, disable the feature.